### PR TITLE
fixes to import for 2.8

### DIFF
--- a/io_scene_lol/__init__.py
+++ b/io_scene_lol/__init__.py
@@ -24,7 +24,7 @@ bl_info = {
     'name': 'Import League of Legends Character files (.skn;.skl)',
     'author': 'Pascal Lis, Zac Berkowitz',
     'version': (0,7),
-    'blender': (2,74,0),
+    'blender': (2,80,0),
     'location': 'File > Import',
     'category': 'Import/Export',
     'api': 31878,

--- a/io_scene_lol/lolMesh.py
+++ b/io_scene_lol/lolMesh.py
@@ -292,13 +292,13 @@ def buildMesh(filepath):
     obj = bpy.data.objects.new('lolMesh', mesh)
 
     #Link object to the current scene
-    scene.objects.link(obj)
+    scene.collection.objects.link(obj)
 
 
     #Create UV texture coords
     texList = []
     uvtexName = 'lolUVtex'
-    obj.data.uv_textures.new(uvtexName)
+    obj.data.uv_layers.new(name=uvtexName)
     uv_layer = obj.data.uv_layers[-1].data  # sets layer to the above texture
     set = []
     for k, loop in enumerate(obj.data.loops):
@@ -319,7 +319,7 @@ def buildMesh(filepath):
     #material = bpy.data.materials.ne(materialName)
     mesh.update() 
     #set active
-    obj.select = True
+    obj.select_set(True)
 
     return {'FINISHED'}
     
@@ -361,7 +361,7 @@ def exportSKN(meshObj, output_filepath, input_filepath, BASE_ON_IMPORT, VERSION)
     #Go into object mode & select only the mesh
     bpy.ops.object.mode_set(mode='OBJECT')
     bpy.ops.object.select_all(action='DESELECT')
-    meshObj.select = True
+    meshObj.select_set(True)
 
     numFaces = len(meshObj.data.loops) // 3
     

--- a/io_scene_lol/lolSkeleton.py
+++ b/io_scene_lol/lolSkeleton.py
@@ -400,7 +400,7 @@ def buildSKL(boneList, version):
                 newBone.parent = parentBone
                 parQuat = boneList[boneParentID].quat
                 boneHead.rotate(parQuat)  # only apply parent rotation to self
-                bone.quat = parQuat * bone.quat  # for children
+                bone.quat = parQuat @ bone.quat  # for childrea
 
                 # parentPos = mathutils.Vector(boneList[boneParentID].position)
                 parentPos = parentBone.head


### PR DESCRIPTION
This PR allows you to use this add on to import to blender 2.8-- I haven't tested export but that seems like a whole different can of worms. @BilbozZ has been doing some extensive work on their fork for export and I would want to merge some of those changes in first before converting anything else into 2.8. 

I would ESPECIALLY like to have BilbozZ@e69677403264b94e7d6985a6c580da3568afa275 since I've noticed that is an issue on import for some meshes, but that would have to be converted to a node based material system.

Thanks for hosting this plugin on github!